### PR TITLE
Making the keymaps key-insensitive

### DIFF
--- a/.sublime/Default.sublime-keymap
+++ b/.sublime/Default.sublime-keymap
@@ -3,35 +3,62 @@
 		"keys": ["t"],
 		"command": "toggle_pack",
 		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}]
-	}, {
+	},
+	{
+		"keys": ["T"],
+		"command": "toggle_pack",
+		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}]
+	},
+	{
 		"keys": ["r"],
 		"command": "renderlist",
 		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}]
-	}, {
+	},
+	{
+		"keys": ["R"],
+		"command": "renderlist",
+		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}]
+	},
+	{
 		"keys": ["i"],
 		"command": "show_info",
 		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}]
-	}, {
+	},
+	{
+		"keys": ["I"],
+		"command": "show_info",
+		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}]
+	},
+	{
 		"keys": ["+"],
 		"command": "change_font_size",
 		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}],
 		"args": {"plus": true}
-	}, {
+	},
+	{
 		"keys": ["-"],
 		"command": "change_font_size",
 		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}],
 		"args": {"plus": false}
-	}, {
+	},
+	{
 		"keys": ["0"],
 		"command": "change_font_size",
 		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}],
 		"args": {"plus": "reset"}
-	}, {
+	},
+	{
 		"keys": ["?"],
 		"command": "toggle_popup_help",
 		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}]
-	}, {
+	},
+	{
 		"keys": ["h"],
+		"command": "open_homepage",
+		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}]
+	}
+	{
+		"keys": ["H"],
 		"command": "open_homepage",
 		"context": [{"key": "selector", "operator": "equal", "operand": "text.plist"}]
 	}


### PR DESCRIPTION
When Caps-Lock is activated, PackageUI keybindings binded to a letter become useless.

This can be really annoying if you don't realize what is the issue.